### PR TITLE
Improve flow when switching between modes

### DIFF
--- a/src/components/ResultsDisplay/ResultsDisplay.test.ts
+++ b/src/components/ResultsDisplay/ResultsDisplay.test.ts
@@ -184,7 +184,7 @@ describe('ResultsDisplay', () => {
     })
 
     it('shows idle state initially', () => {
-      expect(statusMessage.textContent).toBe('Click "Scan Barcode" or "Manual Entry".')
+      expect((resultsArea.classList as any).add).toHaveBeenCalledWith('hidden')
       expect((productInfo.classList as any).add).toHaveBeenCalledWith('hidden')
     })
   })
@@ -257,41 +257,12 @@ describe('ResultsDisplay', () => {
       expect(statusMessage.textContent).toBe('Custom status message')
     })
 
-    it('shows error state', () => {
-      resultsDisplay.showError('Network error')
-
-      expect(errorMessage.textContent).toBe('Network error')
-      expect(statusMessage.textContent).toBe('Error occurred.')
-      expect((resultsArea.classList as any).remove).toHaveBeenCalledWith('hidden')
-    })
-
     it('shows idle state', () => {
       resultsDisplay.showIdleState()
 
-      expect(statusMessage.textContent).toBe('Click "Scan Barcode" or "Manual Entry".')
+      expect((resultsArea.classList as any).add).toHaveBeenCalledWith('hidden')
       expect((productInfo.classList as any).add).toHaveBeenCalledWith('hidden')
       expect(errorMessage.textContent).toBe('')
-    })
-
-    it('shows scanning state', () => {
-      resultsDisplay.showScanningState()
-
-      expect(statusMessage.textContent).toBe('Starting scanner...')
-      expect((productInfo.classList as any).add).toHaveBeenCalledWith('hidden')
-    })
-
-    it('shows manual entry state', () => {
-      resultsDisplay.showManualEntryState()
-
-      expect(statusMessage.textContent).toBe('Enter product details manually.')
-      expect((productInfo.classList as any).add).toHaveBeenCalledWith('hidden')
-    })
-
-    it('shows search state', () => {
-      resultsDisplay.showSearchState()
-
-      expect(statusMessage.textContent).toBe('Enter a food name to search.')
-      expect((productInfo.classList as any).add).toHaveBeenCalledWith('hidden')
     })
   })
 

--- a/src/components/ResultsDisplay/ResultsDisplay.ts
+++ b/src/components/ResultsDisplay/ResultsDisplay.ts
@@ -114,32 +114,8 @@ export class ResultsDisplay {
     this.statusMessage.textContent = message
   }
 
-  showError(message: string): void {
-    this.errorMessage.textContent = message
-    this.statusMessage.textContent = 'Error occurred.'
-    this.show()
-  }
-
   showIdleState(): void {
-    this.statusMessage.textContent = 'Click "Scan Barcode" or "Manual Entry".'
-    this.productInfo.classList.add(CSS_CLASSES.HIDDEN)
-    this.errorMessage.textContent = ''
-  }
-
-  showScanningState(): void {
-    this.statusMessage.textContent = 'Starting scanner...'
-    this.productInfo.classList.add(CSS_CLASSES.HIDDEN)
-    this.errorMessage.textContent = ''
-  }
-
-  showManualEntryState(): void {
-    this.statusMessage.textContent = 'Enter product details manually.'
-    this.productInfo.classList.add(CSS_CLASSES.HIDDEN)
-    this.errorMessage.textContent = ''
-  }
-
-  showSearchState(): void {
-    this.statusMessage.textContent = 'Enter a food name to search.'
+    this.hide()
     this.productInfo.classList.add(CSS_CLASSES.HIDDEN)
     this.errorMessage.textContent = ''
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ class ProteinMeterApp {
   private errorView!: ErrorView
 
   // UI elements
+  private scanBarcodeBtn!: HTMLButtonElement
   private manualEntryBtn!: HTMLButtonElement
   private searchFoodBtn!: HTMLButtonElement
 
@@ -124,8 +125,17 @@ class ProteinMeterApp {
     this.errorView = new ErrorView('error-display')
 
     // Get UI buttons
+    this.scanBarcodeBtn = document.getElementById('scan-barcode-btn') as HTMLButtonElement
     this.manualEntryBtn = document.getElementById('manual-entry-btn') as HTMLButtonElement
     this.searchFoodBtn = document.getElementById('search-food-btn') as HTMLButtonElement
+
+    // Get stop scan button
+    const stopScanBtn = document.getElementById('stop-scan-btn') as HTMLButtonElement
+
+    // Add stop scan button listener
+    stopScanBtn.addEventListener('click', () => {
+      this.showIdle()
+    })
   }
 
   private setupEventListeners(): void {
@@ -146,6 +156,12 @@ class ProteinMeterApp {
   }
 
   private setupUIEventListeners(): void {
+    // Scan barcode button
+    this.scanBarcodeBtn.addEventListener('click', () => {
+      this.errorView.clear()
+      this.showScanning()
+    })
+
     // Manual entry button
     this.manualEntryBtn.addEventListener('click', () => {
       this.errorView.clear()
@@ -267,11 +283,13 @@ class ProteinMeterApp {
   // UI State Management
   private showIdle(): void {
     this.hideAllForms()
+    this.showMainActionButtons()
     this.resultsDisplay.showIdleState()
   }
 
   private showScanning(): void {
     this.hideAllForms()
+    this.hideMainActionButtons()
     this.resultsDisplay.hide()
   }
 
@@ -280,6 +298,7 @@ class ProteinMeterApp {
       this.scanner.stopScanning()
     }
     this.hideAllForms()
+    this.hideMainActionButtons()
     this.manualEntry.show()
     this.resultsDisplay.hide()
   }
@@ -289,18 +308,32 @@ class ProteinMeterApp {
       this.scanner.stopScanning()
     }
     this.hideAllForms()
+    this.hideMainActionButtons()
     this.searchFood.show()
     this.resultsDisplay.hide()
   }
 
   private showResults(): void {
     this.hideAllForms()
+    this.showMainActionButtons()
     this.resultsDisplay.show()
   }
 
   private hideAllForms(): void {
     this.manualEntry.hide()
     this.searchFood.hide()
+  }
+
+  private showMainActionButtons(): void {
+    this.scanBarcodeBtn.classList.remove('hidden')
+    this.manualEntryBtn.classList.remove('hidden')
+    this.searchFoodBtn.classList.remove('hidden')
+  }
+
+  private hideMainActionButtons(): void {
+    this.scanBarcodeBtn.classList.add('hidden')
+    this.manualEntryBtn.classList.add('hidden')
+    this.searchFoodBtn.classList.add('hidden')
   }
 
   private initializePWA(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { ErrorView } from './components/ErrorView/ErrorView'
 import { ProteinCalculator } from './services/calculator/proteinCalculator'
 import { HistoryStorage } from './services/storage/historyStorage'
 import { OpenFoodFactsAPI } from './services/api/openFoodFactsAPI'
-import { EventBus, EVENTS } from './utils/events'
+import { EventBus, EVENTS, type ScanErrorEvent } from './utils/events'
 import type {
   BarcodeScannedEvent,
   ManualEntrySubmitEvent,
@@ -193,9 +193,9 @@ class ProteinMeterApp {
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      this.resultsDisplay.showError(
-        `Failed to fetch product data: ${errorMessage}. Please try again.`
-      )
+      this.eventBus.emit<ScanErrorEvent>(EVENTS.SCAN_ERROR, {
+        error: `Failed to fetch product data: ${errorMessage}. Please try again.`,
+      })
     }
   }
 
@@ -268,13 +268,11 @@ class ProteinMeterApp {
   private showIdle(): void {
     this.hideAllForms()
     this.resultsDisplay.showIdleState()
-    this.resultsDisplay.show()
   }
 
   private showScanning(): void {
     this.hideAllForms()
-    this.resultsDisplay.showScanningState()
-    this.resultsDisplay.show()
+    this.resultsDisplay.hide()
   }
 
   private showManualEntry(): void {


### PR DESCRIPTION
We used to share state across the different modes. Now if you tap on one of the options you focus on that mode.